### PR TITLE
Gemspec: Require a Sequel 5, less than 6.0 (which does not yet exist)

### DIFF
--- a/yard-sequel.gemspec
+++ b/yard-sequel.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
 
-  spec.add_runtime_dependency 'sequel', '~> 4.0'
+  spec.add_runtime_dependency 'sequel', '< 6'
   spec.add_runtime_dependency 'yard', '~> 0.9'
 end

--- a/yard-sequel.gemspec
+++ b/yard-sequel.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
 
-  spec.add_runtime_dependency 'sequel', '< 6'
+  spec.add_runtime_dependency 'sequel', ['>= 4.0', '< 6']
   spec.add_runtime_dependency 'yard', '~> 0.9'
 end


### PR DESCRIPTION
This PR updates the gemspec to point to a newer Sequel version.