### PR TITLE
Travis: drop unuspported Ruby versions, add 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 rvm:
- - 2.0
- - 2.1
- - 2.2
  - 2.3
  - 2.4
+ - 2.5
 script: bundle exec rspec


### PR DESCRIPTION
This PR makes the build matrix smaller by removing those Ruby versions which are no longer supported.