### PR TITLE
README: Drop Gemnasium badge (defunct service)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Gem Version](https://badge.fury.io/rb/yard-sequel.svg)](https://badge.fury.io/rb/yard-sequel)
 [![Build Status](https://travis-ci.org/kmoschcau/yard-sequel.svg?branch=master)](https://travis-ci.org/kmoschcau/yard-sequel)
-[![Dependency Status](https://gemnasium.com/badges/github.com/kmoschcau/yard-sequel.svg)](https://gemnasium.com/github.com/kmoschcau/yard-sequel)
 [![Code Climate](https://codeclimate.com/github/kmoschcau/yard-sequel/badges/gpa.svg)](https://codeclimate.com/github/kmoschcau/yard-sequel)
 [![Coverage Status](https://coveralls.io/repos/github/kmoschcau/yard-sequel/badge.svg?branch=master)](https://coveralls.io/github/kmoschcau/yard-sequel?branch=master)
 [![Inline docs](http://inch-ci.org/github/kmoschcau/yard-sequel.svg?branch=master&style=shields)](http://inch-ci.org/github/kmoschcau/yard-sequel)


### PR DESCRIPTION
This PR removes a badge for a defunct service.