### PR TITLE
Configure RuboCop with a TargetRubyVersion which does not fail on CodeClimate

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 2.3
 Naming/FileName:
   Exclude:
     - lib/yard-sequel.rb


### PR DESCRIPTION
This PR is to make CodeClimate be able to run latest RuboCop on this codebase.

Example output: https://codeclimate.com/github/kmoschcau/yard-sequel/builds/126